### PR TITLE
Correct Spotify login

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ before_install:
   - gem install cocoapods
   - pod repo update
   - pod install
-  - echo $auth > "Convertify/Stores/Auth.swift"
+  - echo $"auth" > "Convertify/Stores/Auth.swift"
 podfile: Podfile
 osx_image: xcode10
 xcode_workspace: Convertify.xcworkspace

--- a/Convertify.xcodeproj/project.pbxproj
+++ b/Convertify.xcodeproj/project.pbxproj
@@ -151,7 +151,6 @@
 				2950B876D9BA100742BD6D38 /* Pods-Convertify-ConvertifyTests.debug.xcconfig */,
 				1EDE49022D8248FFCDB52FE5 /* Pods-Convertify-ConvertifyTests.release.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};

--- a/Convertify/AppDelegate.swift
+++ b/Convertify/AppDelegate.swift
@@ -21,7 +21,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_: UIApplication, didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         SpotifyLogin.shared.configure(clientID: Auth.spotifyClientID, clientSecret: Auth.spotifyClientSecret, redirectURL: URL(string: "convertify://")!)
-
         return true
     }
 
@@ -33,12 +32,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         let viewController = window?.rootViewController as! ViewController
         let pasteBoardValue = UIPasteboard.general.string
 
-        // FIXME: uhhhh this should have an exemption for playlists
-
-        // Only redoes search with new links, doesn't attempt searching when there is no string in pasteboard
+        // Doesn't attempt searching when there is no string in pasteboard
         if pasteBoardValue == nil {
             viewController.initApp(link: "")
-        } else if link != pasteBoardValue {
+        } else {
             link = pasteBoardValue
             viewController.initApp(link: pasteBoardValue ?? "")
         }

--- a/Convertify/Info.plist
+++ b/Convertify/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.3.2</string>
+	<string>0.3.3</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,9 +28,10 @@
 				<string>convertify</string>
 			</array>
 		</dict>
+		<dict/>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>27</string>
+	<string>28</string>
 	<key>LSApplicationCategoryType</key>
 	<string></string>
 	<key>LSApplicationQueriesSchemes</key>

--- a/ConvertifyTests/PlaylistTests.swift
+++ b/ConvertifyTests/PlaylistTests.swift
@@ -17,7 +17,6 @@ class PlaylistTests: XCTestCase {
 
     override func setUp() {
         spotify = SpotifyPlaylistSearcher(token: "")
-
         appleMusic = AppleMusicPlaylistSearcher(token: "")
     }
 


### PR DESCRIPTION
Previously, Spotify login had some bugs that required the application to be force closed and re-opened to convert playlists. 
This fixes that.