### PR TITLE
Removed redundant cocoapods install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: swift
 
 before_install:
-  - gem install cocoapods
   - pod repo update
   - pod install
   - echo "$auth" > "Convertify/Stores/Auth.swift"


### PR DESCRIPTION
Reinstalling cocoapods each install creates a massive slowdown as Travis re downloads the entire Cocoapods repo (about half a gigabyte!)